### PR TITLE
feat: burner wallets deployer contract

### DIFF
--- a/burner/.gitignore
+++ b/burner/.gitignore
@@ -1,1 +1,2 @@
 target
+.snfoundry_cache

--- a/burner/Scarb.lock
+++ b/burner/Scarb.lock
@@ -4,3 +4,11 @@ version = 1
 [[package]]
 name = "burner"
 version = "0.1.0"
+dependencies = [
+ "snforge_std",
+]
+
+[[package]]
+name = "snforge_std"
+version = "0.14.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.14.0#e8cbecee4e31ed428c76d5173eaa90c8df796fe3"

--- a/burner/Scarb.toml
+++ b/burner/Scarb.toml
@@ -1,8 +1,19 @@
 [package]
 name = "burner"
 version = "0.1.0"
-edition = "2023_11"
+edition = "2023_10"
 
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
-
 [dependencies]
+starknet = ">=2.4.0"
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.14.0" }
+
+[[target.starknet-contract]]
+casm = true
+sierra = true
+
+[tool.snforge]
+exit_first = false
+
+[scripts]
+test = "snforge test"

--- a/burner/src/burner_deployer.cairo
+++ b/burner/src/burner_deployer.cairo
@@ -1,0 +1,50 @@
+#[starknet::interface]
+trait IBurnerWalletDeployer<TContractState> {
+    fn deploy_burner_wallet(
+        ref self: TContractState, public_key: felt252
+    ) -> starknet::ContractAddress;
+}
+
+#[starknet::contract]
+mod BurnerWalletDeployer {
+    use core::traits::TryInto;
+    use starknet::syscalls::deploy_syscall;
+
+    // OpenZeppelin preset Account class hash (v0.9.0)
+    const OZ_ACCOUNT_CLASSHASH: felt252 = 0x01148c31dfa5c4708a4e9cf1eb0fd3d4d8ad9ccf09d0232cd6b56bee64a7de9d;
+
+    #[storage]
+    struct Storage {
+        account_class_hash: felt252,
+        salt: felt252
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, account_class_hash: felt252) {
+        self.salt.write(0);
+
+        if account_class_hash == 0 {
+            self.account_class_hash.write(OZ_ACCOUNT_CLASSHASH);
+        }
+        else {
+            self.account_class_hash.write(account_class_hash);
+    }
+    }
+
+    #[abi(embed_v0)]
+    impl BurnerWalletDeployerImpl of super::IBurnerWalletDeployer<ContractState> {
+        fn deploy_burner_wallet(ref self: ContractState, public_key: felt252) -> starknet::ContractAddress {
+            let account_class_hash: starknet::ClassHash = self.account_class_hash.read().try_into().unwrap();
+            let calldata = array![public_key];
+            let salt = self.salt.read();
+
+            let (deployed_address, _) = deploy_syscall(
+                account_class_hash, salt, calldata.span(), false
+            ).unwrap();
+
+            self.salt.write(salt + 1);
+            deployed_address
+        }
+    }
+}
+

--- a/burner/src/lib.cairo
+++ b/burner/src/lib.cairo
@@ -1,1 +1,3 @@
-// burner contract goes in here
+mod burner_deployer;
+
+mod mock;

--- a/burner/src/mock.cairo
+++ b/burner/src/mock.cairo
@@ -1,0 +1,1 @@
+mod account;

--- a/burner/src/mock/account.cairo
+++ b/burner/src/mock/account.cairo
@@ -1,0 +1,9 @@
+#[starknet::contract]
+mod Account {
+
+    #[storage]
+    struct Storage {}
+
+    #[constructor]
+    fn constructor(ref self: ContractState, public_key: felt252) {}
+}

--- a/burner/tests/test_burner_deployer.cairo
+++ b/burner/tests/test_burner_deployer.cairo
@@ -1,0 +1,99 @@
+use starknet::ContractAddress;
+use starknet::class_hash::ClassHash;
+
+use snforge_std::{ declare, ContractClassTrait, get_class_hash, load };
+
+use burner::burner_deployer::{
+    BurnerWalletDeployer,
+    IBurnerWalletDeployerDispatcher,
+    IBurnerWalletDeployerDispatcherTrait
+};
+use burner::mock::account::Account;
+
+fn declare_account_contract() -> felt252 {
+    let account_class = declare('Account');
+    account_class.class_hash.into()
+}
+
+fn deploy_contract_to_test(account_class_hash: felt252) -> ContractAddress {
+    let burnerDeployer = declare('BurnerWalletDeployer');
+
+    let calldata = array![account_class_hash];
+    let burnerDeployerAddress = burnerDeployer.deploy(@calldata).unwrap();
+    burnerDeployerAddress
+}
+
+fn read_storage(contract_address: ContractAddress, selector: felt252) -> felt252 {
+    let loaded = load(contract_address, selector, 1);
+    *loaded.at(0)
+}
+
+#[test]
+fn test_deploy_a_first_account() {
+    // -- Arrange
+    let account_class_hash = declare_account_contract();
+    let burnerDeployerAddress = deploy_contract_to_test(account_class_hash);
+    let dispatcher = IBurnerWalletDeployerDispatcher { contract_address: burnerDeployerAddress };
+
+    let public_key = 0x4ae92c17fc4badd44bb3095170cb5817b9b57539c8babf20ab87c86999c7044;
+
+    // -- Act
+    let account_address = dispatcher.deploy_burner_wallet(public_key);
+
+    // -- Assert
+
+    // check that the account has been correctly deployed
+    let deployed_class_hash = get_class_hash(account_address).into();
+    assert!(account_class_hash == deployed_class_hash, "Account contract was not deployed correctly");
+
+    // check internal storage
+    let internal_salt = read_storage(burnerDeployerAddress, selector!("salt"));
+    let internal_account_class_hash = read_storage(burnerDeployerAddress, selector!("account_class_hash"));
+
+    assert!(internal_salt == 1, "salt has not been updated");
+    assert!(internal_account_class_hash == account_class_hash, "account class hash has not been set correctly");
+}
+
+#[test]
+fn test_deploy_a_second_account() {
+    // -- Arrange
+    let account_class_hash = declare_account_contract();
+    let burnerDeployerAddress = deploy_contract_to_test(account_class_hash);
+    let dispatcher = IBurnerWalletDeployerDispatcher { contract_address: burnerDeployerAddress };
+
+    let public_key = 0x4ae92c17fc4badd44bb3095170cb5817b9b57539c8babf20ab87c86999c7044;
+
+    let first_account = dispatcher.deploy_burner_wallet(public_key);
+
+    // -- Act
+    let second_account = dispatcher.deploy_burner_wallet(public_key);
+
+    // -- Assert
+
+    // be sure that both accounts have not the same address
+    assert!(first_account != second_account, "Both accounts have the same address !");
+
+    // check that the account has been correctly deployed
+    let deployed_class_hash = get_class_hash(second_account).into();
+    assert!(account_class_hash == deployed_class_hash, "Account contract was not deployed correctly");
+
+    // check internal storage
+    let internal_salt = read_storage(burnerDeployerAddress, selector!("salt"));
+
+    assert!(internal_salt == 2, "salt has not been updated");
+}
+
+#[test]
+fn test_use_oz_class_hash_by_default() {
+
+    // -- Arrange
+    let OZ_ACCOUNT_CLASSHASH: felt252 = 0x01148c31dfa5c4708a4e9cf1eb0fd3d4d8ad9ccf09d0232cd6b56bee64a7de9d;
+
+    // -- Act
+    let burnerDeployerAddress = deploy_contract_to_test(0);
+
+    // -- Assert
+    let internal_account_class_hash = read_storage(burnerDeployerAddress, selector!("account_class_hash"));
+    assert!(internal_account_class_hash == OZ_ACCOUNT_CLASSHASH, "account class hash has not been set correctly");
+}
+


### PR DESCRIPTION
## Description

The `BurnerWalletDeployer` contract allows to deploy OZ accounts to be used as burner wallets.

This is done with the `deploy_burner_wallet` which takes the account public key as parameter and returns the created account address.

To not deploy a same account forever, this contract uses an internal `salt` starting from 0 and increased of 1 after each new burner wallet.

## Additional Information

- [x] I have read the [contributing docs](../CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/argentlabs/Starknet-Scaffold/pulls)

## Related Issues

_Closes #27_

